### PR TITLE
remove semver range from output

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -2,7 +2,7 @@ const [, user, repo] = document.location.pathname.match(/\/+([^/]*)\/([^(/|\?)]*
 
 // Are we on a repo page that has a package.json?
 if (user && document.querySelector('.files [title="package.json"]')) {
-  
+
   // Assemble API URL for fetching raw json from github
   const pkgUrl = `https://github.com/${user}/${repo}/blob/master/package.json`;
 
@@ -36,9 +36,7 @@ if (user && document.querySelector('.files [title="package.json"]')) {
 
     const depNames = Object.keys(dependencies).forEach(name => {
       const depUrl = 'https://registry.npmjs.org/' + name
-      const version = dependencies[name]
-
-      const $dep = $("<li><a href='https://npmjs.org/package/" + name + "'>" + name + '</a>&nbsp;<code><small>' + version + '</small></code>&nbsp;</li>')
+      const $dep = $("<li><a href='https://npmjs.org/package/" + name + "'>" + name + '</a>&nbsp;</li>')
       $dep.appendTo($list);
       backgroundFetch(depUrl).then(dep => {
         $dep.append(dep.description)


### PR DESCRIPTION
This PR removes the semver range from the dependency list, because it's not really a helpful thing to see. Name, description, and hyperlink are what matter most. Users can easily view the `package.json` to check semver ranges for all dependencies.

![screen shot 2017-02-01 at 9 57 39 am](https://cloud.githubusercontent.com/assets/2289/22519436/17c3079c-e865-11e6-8447-e6a6f64488bd.png)
