### PR TITLE
Always use ghub.io

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -36,14 +36,10 @@ if (user && document.querySelector('.files [title="package.json"]')) {
 
     const depNames = Object.keys(dependencies).forEach(name => {
       const depUrl = 'https://registry.npmjs.org/' + name
-      const $dep = $("<li><a href='https://npmjs.org/package/" + name + "'>" + name + '</a>&nbsp;</li>')
+      const $dep = $("<li><a href='http://ghub.io/" + name + "'>" + name + '</a>&nbsp;</li>')
       $dep.appendTo($list);
       backgroundFetch(depUrl).then(dep => {
         $dep.append(dep.description)
-
-        if (dep.repository) {
-          $dep.append(" <a href='http://ghub.io/" + dep.name + "'>(repo)</a>")
-        }
       })
     });
   }

--- a/extension/index.js
+++ b/extension/index.js
@@ -2,7 +2,7 @@ const [, user, repo] = document.location.pathname.match(/\/+([^/]*)\/([^(/|\?)]*
 
 // Are we on a repo page that has a package.json?
 if (user && document.querySelector('.files [title="package.json"]')) {
-  
+
   // Assemble API URL for fetching raw json from github
   const pkgUrl = `https://github.com/${user}/${repo}/blob/master/package.json`;
 
@@ -36,9 +36,7 @@ if (user && document.querySelector('.files [title="package.json"]')) {
 
     const depNames = Object.keys(dependencies).forEach(name => {
       const depUrl = 'https://registry.npmjs.org/' + name
-      const version = dependencies[name]
-
-      const $dep = $("<li><a href='https://npmjs.org/package/" + name + "'>" + name + '</a>&nbsp;<code><small>' + version + '</small></code>&nbsp;</li>')
+      const $dep = $("<li><a href='https://npmjs.org/package/" + name + "'>" + name + '</a>&nbsp;</li>')
       $dep.appendTo($list);
       backgroundFetch(depUrl).then(dep => {
         $dep.append(dep.description)


### PR DESCRIPTION
This PR updates the links to always point to ghub.io instead of npmjs.com.

The npm website hasn't changed in years. GitHub is a better place to go to find out what's up with a package.. is it alive? how many maintainers does it have? Does it have tests? etc..

For packages that don't have a GitHub repository, ghub.io redirects to the npmjs.com package page.