### PR TITLE
GitLab support

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -1,27 +1,32 @@
+// Are we on a GitLab instance ?
+const isGitLab = !!document.querySelector('.navbar-gitlab');
 // Are we on a repo page that has a package.json?
-const packageLink = document.querySelector('.files [title="package.json"]');
+const packageLink = document.querySelector('.files [title="package.json"], .tree-item-file-name [title="package.json"]');
 
 if (packageLink) {
   const pkgUrl = packageLink.href;
 
   // Set up list containers and headings
-  const $template = $('#readme').clone().empty().removeAttr('id');
+  const $template = $('#readme, .readme-holder').clone().empty().removeAttr('id');
 
   const $depsList = $("<ol class='deps markdown-body'>");
   const $devDepsList = $("<ol class='deps markdown-body'>");
   const $depsVisBtn = $("<button class='btn btn-sm viz-btn' style='float: right; margin: 5px 5px 0 0;' type='button'>Dependency tree visualization");
 
+  const dependenciesHeader    = isGitLab ? '<div id="dependencies" class="file-title"><strong>Dependencies'         : '<h3 id="dependencies">Dependencies';
+  const devDependenciesHeader = isGitLab ? '<div id="dev-dependencies" class="file-title"><strong>Dev dependencies' : '<h3 id="dev-dependencies">Dev dependencies';
+
   $template.clone()
   .append($depsVisBtn)
-  .append('<h3 id="dependencies">Dependencies', $depsList)
-  .appendTo('.repository-content');
+  .append(dependenciesHeader, $depsList)
+  .appendTo('.repository-content, .tree-content-holder');
 
   $template.clone()
-  .append('<h3 id="dev-dependencies">Dev dependencies', $devDepsList)
-  .appendTo('.repository-content');
+  .append(devDependenciesHeader, $devDepsList)
+  .appendTo('.repository-content, .tree-content-holder');
 
   fetch(pkgUrl, { credentials: 'include' }).then(res => res.text()).then(domStr => {
-    const pkg = JSON.parse($(domStr).find('.blob-wrapper').text());
+    const pkg = JSON.parse($(domStr).find('.blob-wrapper, .blob-content').text());
     $depsVisBtn.wrap(`<a href="http://npm.anvaka.com/#/view/2d/${pkg.name}"></a>`);
     addDependencies(pkg.dependencies, $depsList);
     addDependencies(pkg.devDependencies, $devDepsList);

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "name":"npmhub",
   "version":"2.1.0",
   "manifest_version":2,
-  "description":"Explore npm dependencies on GitHub repos",
+  "description":"Explore npm dependencies on GitHub and GitLab repos",
   "author": "Zeke Sikelianos, Federico Brigante",
   "icons":{
     "16":"icons/icon16.png",
@@ -26,7 +26,8 @@
   "content_scripts":[
     {
       "matches":[
-        "https://github.com/*"
+        "https://github.com/*",
+        "https://gitlab.com/*"
       ],
       "js":[
         "background-fetch.js",


### PR DESCRIPTION
As talked about in #32, this PR adds GitLab support.

For now it only supports gitlab.com but once #31 merged, it should also support private gitlab instances.

![npmhub-gitlab](https://cloud.githubusercontent.com/assets/8517072/22847057/009c0e78-efeb-11e6-9e82-c51d7df33444.png)
