### PR TITLE
Only one empty list

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -14,38 +14,22 @@ const isGitLab = document.querySelector('.navbar-gitlab');
 const packageLink = document.querySelector('.files [title="package.json"], .tree-item-file-name [title="package.json"]');
 
 if (packageLink) {
-  const pkgUrl = packageLink.href;
-
   // Set up list containers and headings
   const $template = $('#readme, .readme-holder').clone().empty().removeAttr('id');
+  const $dependencies = createContainer($template, 'Dependencies');
+  const $devDependencies = createContainer($template, 'Dev Dependencies');
 
-  const $depsList = $('<ol class="deps markdown-body">');
-  const $devDepsList = $('<ol class="deps markdown-body">');
+  // Fetch list of dependencies
+  fetch(packageLink.href, {credentials: 'include'}).then(res => res.text()).then(generateLists);
 
-  const dependenciesHeader = isGitLab ?
-    '<div id="dependencies" class="file-title"><strong>Dependencies' :
-    '<h3 id="dependencies">Dependencies';
-  const devDependenciesHeader = isGitLab ?
-    '<div id="dev-dependencies" class="file-title"><strong>Dev Dependencies' :
-    '<h3 id="dev-dependencies">Dev Dependencies';
-
-  $template.clone()
-  .addClass('npmhub-container')
-  .append(dependenciesHeader, $depsList)
-  .appendTo('.repository-content, .tree-content-holder');
-
-  $template.clone()
-  .append(devDependenciesHeader, $devDepsList)
-  .appendTo('.repository-content, .tree-content-holder');
-
-  fetch(pkgUrl, {credentials: 'include'}).then(res => res.text()).then(domStr => {
+  function generateLists(domStr) {
     const json = $(domStr).find('.blob-wrapper, .blob-content').text();
     const pkg = JSON.parse(json);
     const dependencies = Object.keys(pkg.dependencies || {});
     const devDependencies = Object.keys(pkg.devDependencies || {});
 
-    addDependencies(dependencies, $depsList);
-    addDependencies(devDependencies, $devDepsList);
+    addDependencies($dependencies, dependencies);
+    addDependencies($devDependencies, devDependencies);
 
     if (dependencies.length && !pkg.private) {
       $('<a class="btn btn-sm">')
@@ -55,22 +39,35 @@ if (packageLink) {
         float: 'right',
         margin: 5
       })
-      .prependTo('.npmhub-container');
+      .prependTo($dependencies);
     }
-  });
+  }
 
-  function addDependencies(dependencies, $list) {
-    if (!dependencies.length) {
-      return $list.append('<li class="empty">No dependencies! 🎉</li>');
-    }
+  function createContainer($template, title) {
+    // Create header
+    const dependenciesHeader = isGitLab ?
+      `<div class="file-title"><strong>${title}` :
+      `<h3>${title}`;
 
-    dependencies.forEach(name => {
-      const depUrl = 'https://registry.npmjs.org/' + name;
-      const $dep = $(`<li><a href='http://ghub.io/${esc(name)}'>${esc(name)}</a>&nbsp;</li>`);
-      $dep.appendTo($list);
-      backgroundFetch(depUrl).then(dep => {
-        $dep.append(dep.description);
+    // Merge all and add to page
+    return $template.clone()
+    .append(dependenciesHeader, '<ol class="deps markdown-body">')
+    .appendTo('.repository-content, .tree-content-holder');
+  }
+
+  function addDependencies($container, list) {
+    const $list = $container.find('.deps');
+    if (list.length) {
+      list.forEach(name => {
+        const depUrl = 'https://registry.npmjs.org/' + name;
+        const $dep = $(`<li><a href='http://ghub.io/${esc(name)}'>${esc(name)}</a>&nbsp;</li>`);
+        $dep.appendTo($list);
+        backgroundFetch(depUrl).then(dep => {
+          $dep.append(dep.description);
+        });
       });
-    });
+    } else {
+      $list.append('<li class="empty">No dependencies! 🎉</li>');
+    }
   }
 }

--- a/extension/index.js
+++ b/extension/index.js
@@ -17,7 +17,6 @@ if (packageLink) {
   // Set up list containers and headings
   const $template = $('#readme, .readme-holder').clone().empty().removeAttr('id');
   const $dependencies = createContainer($template, 'Dependencies');
-  const $devDependencies = createContainer($template, 'Dev Dependencies');
 
   // Fetch list of dependencies
   fetch(packageLink.href, {credentials: 'include'}).then(res => res.text()).then(generateLists);
@@ -29,7 +28,11 @@ if (packageLink) {
     const devDependencies = Object.keys(pkg.devDependencies || {});
 
     addDependencies($dependencies, dependencies);
-    addDependencies($devDependencies, devDependencies);
+
+    // Don't show dev dependencies if there are absolutely no dependencies
+    if (dependencies.length || devDependencies.length) {
+      addDependencies(createContainer($template, 'Dev Dependencies'), devDependencies);
+    }
 
     if (dependencies.length && !pkg.private) {
       $('<a class="btn btn-sm">')


### PR DESCRIPTION
1. Code streamlined.
2. This will only leave one box saying “No dependencies” instead of two. Example: https://github.com/bfred-it/random-encoder

* Based on no-anvaka branch