### PR TITLE
Update anvaka button label

### DIFF
--- a/extension/index.js
+++ b/extension/index.js
@@ -39,7 +39,7 @@ async function init() {
   }
 
   if (dependencies.length && !pkg.private) {
-    const link = html`<a class="npmhub-anvaka btn btn-sm">Dependency tree visualization`;
+    const link = html`<a class="npmhub-anvaka btn btn-sm">Visualize full tree`;
     link.href = `http://npm.anvaka.com/#/view/2d/${esc(pkg.name)}`;
     dependenciesBox.insertBefore(link, dependenciesBox.firstChild);
   }


### PR DESCRIPTION
This is consistent with the rest of GitHub's own buttons

<img width="1007" alt="screen shot" src="https://cloud.githubusercontent.com/assets/1402241/25909089/a4655508-35de-11e7-941b-1faea7bf8257.png">
