### PR TITLE
Add `Open on npmjs.com` button

### DIFF
--- a/extension/index.css
+++ b/extension/index.css
@@ -20,6 +20,7 @@ li.empty {
 .npmhub-header .btn {
   float: right;
   margin: 5px;
+  margin-left: 0;
 }
 .deps:empty:before {
   display: block;

--- a/extension/index.css
+++ b/extension/index.css
@@ -14,7 +14,10 @@
 li.empty {
   opacity: 0.6;
 }
-.npmhub-anvaka {
+.npmhub-header {
+  float: right;
+}
+.npmhub-header .btn {
   float: right;
   margin: 5px;
 }

--- a/extension/index.js
+++ b/extension/index.js
@@ -43,18 +43,22 @@ async function init() {
   }
 
   if (!pkg.private) {
-    const realPkg = await window.backgroundFetch(getPkgUrl(pkg.name));
-    if (realPkg.name) { // if 404, realPkg === {}
-      const link = html`<a class="btn btn-sm">Open on npmjs.com`;
-      link.href = `https://www.npmjs.com/package/${esc(pkg.name)}`;
-      dependenciesBox.firstChild.appendChild(link);
-
-      if (dependencies.length) {
-        const link = html`<a class="btn btn-sm">Visualize full tree`;
-        link.href = `http://npm.anvaka.com/#/view/2d/${esc(pkg.name)}`;
+    window.backgroundFetch(getPkgUrl(pkg.name))
+    .then(realPkg => {
+      if (realPkg.name) { // if 404, realPkg === {}
+        const link = html`<a class="btn btn-sm">Open on npmjs.com`;
+        link.href = `https://www.npmjs.com/package/${esc(pkg.name)}`;
         dependenciesBox.firstChild.appendChild(link);
+
+        if (dependencies.length) {
+          const link = html`<a class="btn btn-sm">Visualize full tree`;
+          link.href = `http://npm.anvaka.com/#/view/2d/${esc(pkg.name)}`;
+          dependenciesBox.firstChild.appendChild(link);
+        }
       }
-    }
+    }, err => {
+      console.warn('npmhub: there was an error while pinging the current package on npmjs.org', err);
+    });
   }
 }
 

--- a/extension/index.js
+++ b/extension/index.js
@@ -43,6 +43,12 @@ async function init() {
     link.href = `http://npm.anvaka.com/#/view/2d/${esc(pkg.name)}`;
     dependenciesBox.insertBefore(link, dependenciesBox.firstChild);
   }
+  
+  if (!pkg.private) {
+    const link = html`<a class="npmhub-anvaka btn btn-sm">Open on npmjs.com`;
+    link.href = `https://www.npmjs.com/package/${esc(pkg.name)}`;
+    dependenciesBox.insertBefore(link, dependenciesBox.firstChild);
+  }
 }
 
 function createBox(title) {


### PR DESCRIPTION
Some packages don't link to the npmjs page, so it'd be nice to have a button that is consistently available. Also it wouldn't be terrible to add a few further npm-related features.

<img width="995" alt="screen shot" src="https://cloud.githubusercontent.com/assets/1402241/25909209/fe86092e-35de-11e7-8e7d-9d922a4c244a.png">
