### PR TITLE
Use event pages instead of staying in background persistently

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -18,7 +18,8 @@
   "background": {
     "scripts": [
       "background-fetch.js"
-    ]
+    ],
+    "persistent": false
   },
   "permissions": [
     "https://registry.npmjs.org/"


### PR DESCRIPTION
There’s no need to have the extension’s background page run constantly in the background, so make it launch on demand to save RAM.

https://developer.chrome.com/extensions/event_pages