### PR TITLE
Add build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-dist
+extension/**/*.js
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,3 @@ deploy:
   script: npm run release
   on:
       branch: master
-      
-      # the deployment will be skipped if the last commit doesn't touch the extension's files
-      condition: $(git diff-tree --no-commit-id --name-only -r HEAD | sed -n '/extension\// q 1'; echo $?) = 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '7'
+  - node
 branches:
   only: master
 env:
@@ -8,7 +8,7 @@ env:
 deploy:
   provider: script
   skip_cleanup: true
-  script: npm run update-version; npm run release-cws; npm run release-amo
+  script: npm run release
   on:
       branch: master
       

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -17,7 +17,7 @@
   },
   "background": {
     "scripts": [
-      "background-fetch.js"
+      "background.js"
     ],
     "persistent": false
   },
@@ -31,7 +31,6 @@
         "https://gitlab.com/*"
       ],
       "js": [
-        "background-fetch.js",
         "index.js"
       ],
       "css": [

--- a/lib/background-fetch.js
+++ b/lib/background-fetch.js
@@ -17,20 +17,19 @@ if (chrome.runtime.getBackgroundPage) {
     }
     return true; // Tell browser to await response
   });
-} else {
-  // Setup in content script
-  window.backgroundFetch = function (...args) {
-    return new Promise((resolve, reject) => {
-      chrome.runtime.sendMessage({
-        action: 'fetch',
-        arguments: args
-      }, response => {
-        if (String(response).startsWith('Error')) {
-          reject(new Error(response.replace(/Error:? ?/, '')));
-        } else {
-          resolve(response);
-        }
-      });
+}
+
+export default function backgroundFetch(...args) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage({
+      action: 'fetch',
+      arguments: args
+    }, response => {
+      if (String(response).startsWith('Error')) {
+        reject(new Error(response.replace(/Error:? ?/, '')));
+      } else {
+        resolve(response);
+      }
     });
-  };
+  });
 }

--- a/lib/parse-html.js
+++ b/lib/parse-html.js
@@ -1,0 +1,13 @@
+// Get DOM node(s) from HTML
+export default function (html) {
+  if (html.raw) {
+    // Shortcut for html`text` instead of html(`text`)
+    html = String.raw(...arguments);
+  }
+
+  const fragment = document.createRange().createContextualFragment(html.trim());
+  if (fragment.firstChild === fragment.lastChild) {
+    return fragment.firstChild;
+  }
+  return fragment;
+}

--- a/package.json
+++ b/package.json
@@ -2,26 +2,42 @@
   "name": "npmhub",
   "version": "0.0.0",
   "description": "",
-  "devDependencies": {
-    "chrome-webstore-upload-cli": "^1.0.0",
-    "dot-json": "^1.0.3",
-    "webext": "^1.9.1-with-submit.1",
-    "xo": "^0.18.2"
-  },
   "private": true,
   "author": "zeke",
   "license": "MIT",
   "scripts": {
     "test": "xo",
+    "build": "rollup -c",
+    "watch": "npm run build --silent -- --watch",
     "release-amo": "cd extension && webext submit",
     "release-cws": "cd extension && webstore upload --auto-publish",
+    "release": "npm run build && npm run update-version && npm run release-amo && npm run release-cws",
     "update-version": "dot-json extension/manifest.json version $(date -u +%Y.%-m.%-d.%-H%M)"
   },
   "xo": {
     "space": 2,
+    "ignores": [
+      "extension/**"
+    ],
+    "rules": {
+      "import/no-unassigned-import": 0
+    },
     "envs": [
       "browser",
       "webextensions"
     ]
+  },
+  "devDependencies": {
+    "chrome-webstore-upload-cli": "^1.0.0",
+    "dot-json": "^1.0.3",
+    "rollup": "^0.43.0",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-watch": "^4.0.0",
+    "webext": "^1.9.1-with-submit.1",
+    "xo": "^0.18.2"
+  },
+  "dependencies": {
+    "escape-goat": "^1.1.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,18 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
+import commonJS from 'rollup-plugin-commonjs';
+
+export default [
+  'src/index.js',
+  'src/background.js'
+].map(entry => ({
+  entry,
+  dest: entry.replace('src', 'extension'),
+  plugins: [
+    nodeResolve({
+      browser: true
+    }),
+    commonJS()
+  ],
+  format: 'iife',
+  sourceMap: process.env.SOURCEMAP || false
+}));

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,1 @@
+import '../lib/background-fetch';

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,8 @@
+import {escape as esc} from 'escape-goat';
+import backgroundFetch from '../lib/background-fetch';
+import html from '../lib/parse-html';
+
 const packageLink = document.querySelector('.files [title="package.json"], .tree-item-file-name [title="package.json"]');
-
-// Escape HTML
-function esc(str) {
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-// Get DOM node from HTML
-function html(html) {
-  if (html.raw) {
-    // Shortcut for html`text` instead of html(`text`)
-    html = String.raw(...arguments);
-  }
-
-  const fragment = document.createRange().createContextualFragment(html.trim());
-  if (fragment.firstChild === fragment.lastChild) {
-    return fragment.firstChild;
-  }
-  return fragment;
-}
 
 function getPkgUrl(name) {
   return 'https://registry.npmjs.org/' + name.replace('/', '%2F');
@@ -45,7 +25,7 @@ async function init() {
   }
 
   if (!pkg.private) {
-    window.backgroundFetch(getPkgUrl(pkg.name))
+    backgroundFetch(getPkgUrl(pkg.name))
     .then(realPkg => {
       if (realPkg.name) { // If 404, realPkg === {}
         const link = html`<a class="btn btn-sm">Open on npmjs.com`;
@@ -86,7 +66,7 @@ function addDependencies(containerEl, list) {
     list.forEach(async name => {
       const depEl = html`<li><a href='http://ghub.io/${esc(name)}'>${esc(name)}</a>&nbsp;</li>`;
       listEl.appendChild(depEl);
-      const dep = await window.backgroundFetch(getPkgUrl(name));
+      const dep = await backgroundFetch(getPkgUrl(name));
       depEl.appendChild(html(esc(dep.description)));
     });
   } else {


### PR DESCRIPTION
Since more files are coming in #31 and #54, I thought I'd put in place a rollup-based build system. 

Unlike with browserify and webpack, the modules are essentially invisible in the output file. The only change is that it's now wrapped in an IIFE.

```sh
npm run build # builds all files from `src` into `extension`
npm run watch # same, but it will automatically re-build when the files change
```