### PR TITLE
Removes box from no dependencies text

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -114,7 +114,7 @@ function addDependencies(containerEl, list) {
       depEl.querySelector('a').href = parseRepoUrl(dep);
     });
   } else {
-    listEl.appendChild(html`<li class="npmhub-empty">No dependencies! 🎉</li>`);
+    listEl.appendChild(html`<li class="npmhub-empty">No dependencies!</li>`);
   }
 }
 


### PR DESCRIPTION
Installed this extension and it looks great. The only issue was this
seemingly broken unicode symbol rendering as a box with the "No
Dependencies" text. Not sure if this renders as emoji or something else
for other users, but on Arch Linux in Google Chrome it appears as a
rectangle and looks broken.