### PR TITLE
Shorten version with bfred-it/daily-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ branches:
   only: master
 env:
   - EXTENSION_ID=kbbbjimdjbjclaebffknlabpogocablj
+
+cache:
+  directories:
+  - $HOME/.npm-daily-version
+
 deploy:
   provider: script
   skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "release-amo": "cd extension && webext submit",
     "release-cws": "cd extension && webstore upload --auto-publish",
     "release": "npm run build && npm run update-version && npm run release-amo && npm run release-cws",
-    "update-version": "dot-json extension/manifest.json version $(date -u +%Y.%-m.%-d.%-H%M)"
+    "update-version": "dot-json extension/manifest.json version $(daily-version Y)"
   },
   "xo": {
     "space": 2,
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "chrome-webstore-upload-cli": "^1.0.0",
+    "daily-version": "^0.10.1",
     "dot-json": "^1.0.3",
     "rollup": "^0.43.0",
     "rollup-plugin-commonjs": "^8.0.2",


### PR DESCRIPTION
https://github.com/bfred-it/daily-version

Let's wait a day before merging this. The first version generated by `daily-version` has to be higher than the current one, but `daily-version` doesn't know what the current version is until its second run.