### PR TITLE
By default, link to npm, not ghub.io

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -146,7 +146,7 @@ function addDependencies(containerEl, list) {
   const listEl = containerEl.querySelector('.npmhub-deps');
   if (list.length > 0) {
     list.forEach(async name => {
-      const depEl = html`<li><a href='http://ghub.io/${esc(name)}'>${esc(name)}</a>&nbsp;</li>`;
+      const depEl = html`<li><a href='https://www.npmjs.com/package/${esc(name)}'>${esc(name)}</a>&nbsp;</li>`;
       listEl.appendChild(depEl);
       const dep = await fetch(getPkgUrl(name)).then(r => r.json());
       depEl.appendChild(html(esc(dep.description)));


### PR DESCRIPTION
Since #77, `ghub.io` doesn't add anything to npmhub since it supports a lower number of `repository` formats.

It's best to just link to `npmjs.org` so if dependencies are 404s (#79) the user will be linked to the official 404 page.