### PR TITLE
Fix support for custom repo URLs

### DIFF
--- a/src/lib/parse-repo-url.js
+++ b/src/lib/parse-repo-url.js
@@ -16,7 +16,7 @@ function unknownHostedUrl(url) {
       'https:' :
       'http:';
     return protocol + '//' + (url.host || '') +
-      url.path.replace(/\.git$/, '');
+      url.pathname.replace(/\.git$/, '');
   } catch (err) {/**/}
 }
 


### PR DESCRIPTION
Example repo with dependency: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread

Example of repository field value: https://github.com/babel/babel/blob/f76ac0b/packages/babel-core/package.json#L9