### PR TITLE
Visually separate private/failed repos

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -14,6 +14,9 @@
 li.npmhub-empty {
   opacity: 0.6;
 }
+.npmhub-deps em {
+  color: darkgray;
+}
 .npmhub-header .btn {
   position: relative;
   z-index: 1; /* Necessary for GitLab */


### PR DESCRIPTION
# Before 

<img width="442" alt="screen shot" src="https://user-images.githubusercontent.com/1402241/33621350-65147f50-da25-11e7-8c80-0034a9ab4c08.png">


# After 

<img width="438" alt="screen shot" src="https://user-images.githubusercontent.com/1402241/33621256-2166a6a2-da25-11e7-99d6-580775e53cec.png">
