### PR TITLE
Modified html to match github's default styling

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -3,13 +3,6 @@
   padding: 0 !important;
   margin: 0 !important; /* gitlab */
 }
-.npmhub-deps > li {
-  padding: 10px;
-  border-bottom: 1px solid #DDD;
-}
-.npmhub-deps > li:last-child {
-  border-bottom: none;
-}
 li.npmhub-empty {
   opacity: 0.6;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -1,6 +1,6 @@
 .npmhub-deps {
-  list-style: none;
-  padding: 0 !important;
+  /*list-style: none;
+  padding: 0 !important;*/
   margin: 0 !important; /* gitlab */
 }
 .npmhub-empty {
@@ -14,9 +14,9 @@
   margin-right: 3px;
 }
 .npmhub-header .btn {
-  position: relative;
+  /*position: relative;*/
   z-index: 1; /* Necessary for GitLab */
-  margin: 3px 0;
+  /*margin: 3px 0;*/
 }
 .npmhub-deps:empty:before {
   display: block;

--- a/source/content.css
+++ b/source/content.css
@@ -3,7 +3,7 @@
   padding: 0 !important;
   margin: 0 !important; /* gitlab */
 }
-li.npmhub-empty {
+.npmhub-empty {
   opacity: 0.6;
 }
 .npmhub-deps em {

--- a/source/content.js
+++ b/source/content.js
@@ -31,8 +31,12 @@ function isPackageJson() {
 }
 
 function addHeaderLink(box, name, url) {
+  isGitLab() ?
   box.firstElementChild.prepend(doma(`
     <a class="btn btn-sm BtnGroup-item" href="${url}">${name}</a>
+  `)) :
+  box.querySelector('.Box-header').append(doma(`
+    <a class="btn btn-sm" href="${url}">${name}</a>
   `));
 }
 
@@ -112,13 +116,16 @@ async function getPackageJson() {
 function createBox(title, container) {
   /* eslint-disable indent */
   const box = doma.one(`
-    <div class="Box mt-5 npmhub-deps">
-      <div class="npmhub-header BtnGroup"></div>
+    <div class="Box mt-5">
       ${
         isGitLab() ?
-        `<div class="file-title"><strong>${title}</strong></div>` :
-        `<div class="Box-header lh-condensed px-3 py-2"><h3 class="Box-title">${title}</h3></div>`
+        `<div class="npmhub-header BtnGroup"></div>
+        <div class="file-title"><strong>${title}</strong></div>` :
+        `<div class="Box-header lh-condensed py-2 d-flex flex-items-center">
+            <h3 class="Box-title overflow-hidden flex-auto">${title}</h3>
+        </div>`
       }
+      <ul class="npmhub-deps"></ul>
     </div>
   `);
   /* eslint-enable indent */
@@ -129,11 +136,11 @@ function createBox(title, container) {
 
 async function addDependency(name, container) {
   const depEl = doma.one(`
-    <div class="Box-row lh-condensed px-3 py-2 border-top">
+    <li class="Box-row">
       <a href='https://www.npmjs.com/package/${htmlEscape(name)}'>
         ${htmlEscape(name)}
       </a>
-    </div>
+    </li>
   `);
   container.append(depEl);
 
@@ -158,12 +165,12 @@ async function addDependency(name, container) {
 }
 
 function addDependencies(containerEl, list) {
-  const listEl = containerEl;
+  const listEl = containerEl.querySelector('.npmhub-deps');
   if (!list) {
     listEl.append(doma(`
-      <div class="Box-row lh-condensed px-3 py-2 npmhub-empty">
+      <li class="Box-row npmhub-empty">
         <em>There was a network error.</em>
-      </div>
+      </li>
     `));
   } else if (list.length > 0) {
     for (const name of list) {
@@ -171,10 +178,10 @@ function addDependencies(containerEl, list) {
     }
   } else {
     listEl.append(doma(`
-      <div class="Box-row lh-condensed px-3 py-2 npmhub-empty">
+      <li class="Box-row npmhub-empty">
         No dependencies!
         <g-emoji class="g-emoji" alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png">🎉</g-emoji>
-      </div>
+      </li>
     `));
   }
 }

--- a/source/content.js
+++ b/source/content.js
@@ -112,14 +112,13 @@ async function getPackageJson() {
 function createBox(title, container) {
   /* eslint-disable indent */
   const box = doma.one(`
-    <div class="Box Box--condensed mt-5 file-holder">
+    <div class="Box mt-5 npmhub-deps">
       <div class="npmhub-header BtnGroup"></div>
       ${
         isGitLab() ?
         `<div class="file-title"><strong>${title}</strong></div>` :
-        `<h3 class="Box-header Box-title px-2">${title}</h3>`
+        `<div class="Box-header lh-condensed px-3 py-2"><h3 class="Box-title">${title}</h3></div>`
       }
-      <ol class="npmhub-deps markdown-body"></ol>
     </div>
   `);
   /* eslint-enable indent */
@@ -130,11 +129,11 @@ function createBox(title, container) {
 
 async function addDependency(name, container) {
   const depEl = doma.one(`
-    <li>
+    <div class="Box-row lh-condensed px-3 py-2 border-top">
       <a href='https://www.npmjs.com/package/${htmlEscape(name)}'>
         ${htmlEscape(name)}
       </a>
-    </li>
+    </div>
   `);
   container.append(depEl);
 
@@ -159,12 +158,12 @@ async function addDependency(name, container) {
 }
 
 function addDependencies(containerEl, list) {
-  const listEl = containerEl.querySelector('.npmhub-deps');
+  const listEl = containerEl;
   if (!list) {
     listEl.append(doma(`
-      <li class="npmhub-empty">
+      <div class="Box-row lh-condensed px-3 py-2 npmhub-empty">
         <em>There was a network error.</em>
-      </li>
+      </div>
     `));
   } else if (list.length > 0) {
     for (const name of list) {
@@ -172,10 +171,10 @@ function addDependencies(containerEl, list) {
     }
   } else {
     listEl.append(doma(`
-      <li class="npmhub-empty">
+      <div class="Box-row lh-condensed px-3 py-2 npmhub-empty">
         No dependencies!
         <g-emoji class="g-emoji" alias="tada" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f389.png">🎉</g-emoji>
-      </li>
+      </div>
     `));
   }
 }


### PR DESCRIPTION
This was brought up in https://github.com/StylishThemes/GitHub-Dark/issues/1088. Not all scenarios were tested (including GitLab) so there might be some tweaking needed.

The overall html is based on the [Dependency Graph](https://github.com/npmhub/npmhub/network/dependencies) page and the utility classes in [Primer](https://primer.style/css/utilities).

Preview of what the changes look like.

![image](https://user-images.githubusercontent.com/831974/77655913-7f76a880-6f49-11ea-9b27-c110aad8485b.png)