### PR TITLE
Don't show `undefined` if a description is missing

### DIFF
--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -35,8 +35,8 @@
                   <em>Not published or private.</em>
                 {:else if info.error}
                   <em>There was a network error.</em>
-                {:else}
-                  {info.description || ''}
+                {:else if info.description}
+                  {info.description}
                 {/if}
               {/await}
             </li>

--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -37,6 +37,8 @@
                   <em>There was a network error.</em>
                 {:else if info.description}
                   {info.description}
+                {:else}
+                  <em>No description.</em>
                 {/if}
               {/await}
             </li>

--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -36,7 +36,7 @@
                 {:else if info.error}
                   <em>There was a network error.</em>
                 {:else}
-                  {info.description}
+                  {info.description || ''}
                 {/if}
               {/await}
             </li>


### PR DESCRIPTION
Currently, npmhub will render "undefined" if package.json does not contain a description field.
![github com_natemoo-re_natemoo-re](https://user-images.githubusercontent.com/35831069/91081776-394d7e80-e67a-11ea-9542-493aa1f6af59.png)

This PR fix the behaviour by rendering an empty string instead of "undefined".

