### PR TITLE
Fix copy-paste error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ GitHub Enterprise is also supported by right-clicking on <a href="https://user-i
 
 [<img src="https://raw.githubusercontent.com/alrra/browser-logos/90fdf03c/src/safari/safari_128x128.png" width="48" alt="Safari" valign="middle">][link-safari] [<img valign="middle" src="https://img.shields.io/itunes/v/1542090429.svg?label=%20">][link-safari]
 
-[<img src="https://raw.githubusercontent.com/iamcal/emoji-data/08ec822c38e0b7a6fea0b92a9c42e02b6ba24a84/img-apple-160/1f99a.png" width="48" valign="middle">](https://github.com/sponsors/fregante) _If you love Refined GitHub, consider [sponsoring or hiring](https://github.com/sponsors/fregante) the maintainer [@fregante](https://twitter.com/fregante)_
+[<img src="https://raw.githubusercontent.com/iamcal/emoji-data/08ec822c38e0b7a6fea0b92a9c42e02b6ba24a84/img-apple-160/1f99a.png" width="48" valign="middle">](https://github.com/sponsors/fregante) _If you love npmhub, consider [sponsoring or hiring](https://github.com/sponsors/fregante) the maintainer [@fregante](https://twitter.com/fregante)_
 
 ## Design
 


### PR DESCRIPTION
Hi @fregante! I noticed the README says:

>If you love Refined GitHub, consider sponsoring ...

But this project isn't Refined GitHub, so I was thinking that that's a copy/paste error.