### PR TITLE
Avoid redirects in links

### DIFF
--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -97,9 +97,9 @@
 
             <ul class="dropdown-menu dropdown-menu-sw">
               <li><a class="dropdown-item" href="https://www.unpkg.com/browse/{package_.name}@latest/">Contents</a></li>
-              <li><a class="dropdown-item" href="https://bundlephobia.com/result?p={package_.name}">BundlePhobia</a></li>
+              <li><a class="dropdown-item" href="https://bundlephobia.com/package/{package_.name}">BundlePhobia</a></li>
               <li><a class="dropdown-item" href="https://packagephobia.com/result?p={package_.name}">PackagePhobia</a></li>
-              <li><a class="dropdown-item" href="https://npm.broofa.com/?q={package_.name}">Dependency tree</a></li>
+              <li><a class="dropdown-item" href="https://npmgraph.js.org/?q={package_.name}">Dependency tree</a></li>
             </ul>
           </details>
         {/if}


### PR DESCRIPTION
- [ ] unpkg also redirects `@latest/` to `@5.0.0/`, which can probably be avoided