### PR TITLE
update URL for npmgraph

### DIFF
--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -99,7 +99,7 @@
               <li><a class="dropdown-item" href="https://www.unpkg.com/browse/{package_.name}@latest/">Contents</a></li>
               <li><a class="dropdown-item" href="https://bundlephobia.com/result?p={package_.name}">BundlePhobia</a></li>
               <li><a class="dropdown-item" href="https://packagephobia.com/result?p={package_.name}">PackagePhobia</a></li>
-              <li><a class="dropdown-item" href="https://npm.broofa.com/?q={package_.name}">Dependency tree</a></li>
+              <li><a class="dropdown-item" href="https://npmgraph.js.org/?q={package_.name}">Dependency tree</a></li>
             </ul>
           </details>
         {/if}


### PR DESCRIPTION
npmgraph was moved to npmgraph.js.org in https://github.com/npmgraph/npmgraph/pull/58
