### PR TITLE
Meta: Add one more example URL to the docs

### DIFF
--- a/INSTALLED.md
+++ b/INSTALLED.md
@@ -3,4 +3,4 @@
 There's nothing to configure. Just surf around on GitHub and whenever you're viewing a repo with npm dependencies, you'll see them listed below the README. For a good example, check out these two dependency lists:
 
 - [**github.com**/sindresorhus/delay#dependencies](https://github.com/sindresorhus/delay#dependencies)
-- [**github.com**/sindresorhus/refined-github#dependencies](https://github.com/sindresorhus/refined-github#dependencies)
+- [**github.com**/fregante/github-url-detection#dependencies](https://github.com/fregante/github-url-detection#dependencies)

--- a/INSTALLED.md
+++ b/INSTALLED.md
@@ -3,3 +3,4 @@
 There's nothing to configure. Just surf around on GitHub and whenever you're viewing a repo with npm dependencies, you'll see them listed below the README. For a good example, check out these two dependency lists:
 
 - [**github.com**/sindresorhus/delay#dependencies](https://github.com/sindresorhus/delay#dependencies)
+- [**github.com**/sindresorhus/refined-github#dependencies](https://github.com/sindresorhus/refined-github#dependencies)


### PR DESCRIPTION
INSTALLED.md reads
> For a good example, check out these two dependency lists:

To maintain that claim correctly, I have added another URL to the list.

I understand that this was previously used to demonstrate how the extension works on both GitHub and GitLab.

This could also be changed as follows too :
```diff
-There's nothing to configure. Just surf around on GitHub and whenever you're viewing a repo with npm dependencies, you'll see them listed below the README. For a good example, check out these two dependency lists:
-
-- [**github.com**/sindresorhus/delay#dependencies](https://github.com/sindresorhus/delay#dependencies)
-- [**github.com**/sindresorhus/refined-github#dependencies](https://github.com/sindresorhus/refined-github#dependencies)
+There's nothing to configure. Just surf around on GitHub and whenever you're viewing a repo with npm dependencies, you'll see them listed below the README. For a good example, check out the dependency list for https://github.com/sindresorhus/delay.
```

Whichever is preferred.
