### PR TITLE
Add `#dependencies` deeplink for npmhub

### DIFF
--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -80,6 +80,7 @@
   });
 </script>
 
+<span id="dependencies"></span>
 <Box dependencies={packagePromise.then(package_ => package_.dependencies)}>
   {#if !isPackageJson}
     <HeaderLink href={packageURL} label="package.json"/>

--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -80,7 +80,6 @@
   });
 </script>
 
-<span id="dependencies"></span>
 <Box dependencies={packagePromise.then(package_ => package_.dependencies)}>
   {#if !isPackageJson}
     <HeaderLink href={packageURL} label="package.json"/>

--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -4,7 +4,7 @@
 </script>
 
 
-<div id="dependencies" class="Box Box--condensed mt-5 file-holder">
+<div class="Box Box--condensed mt-5 file-holder">
   <div class="npmhub-header BtnGroup">
     <slot></slot>
   </div>

--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -1,10 +1,14 @@
 <script>
   export let type = '';
   export let dependencies;
+  export let id = 'dependencies';
+  if (type !== '') {
+    id = type.toLowerCase().trim().replace(/\s+/, '-').concat('-', id);
+  }
 </script>
 
 
-<div class="Box Box--condensed mt-5 file-holder">
+<div {id} class="Box Box--condensed mt-5 file-holder">
   <div class="npmhub-header BtnGroup">
     <slot></slot>
   </div>

--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -4,7 +4,7 @@
 </script>
 
 
-<div class="Box Box--condensed mt-5 file-holder">
+<div id="dependencies" class="Box Box--condensed mt-5 file-holder">
   <div class="npmhub-header BtnGroup">
     <slot></slot>
   </div>

--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -1,10 +1,7 @@
 <script>
   export let type = '';
   export let dependencies;
-  export let id = 'dependencies';
-  if (type !== '') {
-    id = type.toLowerCase().trim().replace(/\s+/, '-').concat('-', id);
-  }
+  export let id = type.toLowerCase() + 'dependencies';
 </script>
 
 


### PR DESCRIPTION
Update HTML ID for the dependencies table for easy reach

This was missed when re-writing with svelte ( https://github.com/npmhub/npmhub/pull/136#issuecomment-909034295 )
