### PR TITLE
Update header styles to match the readme

### DIFF
--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -6,8 +6,8 @@
 
 
 <div {id} class="Box Box--condensed mt-5 file-holder">
-  <div class="d-flex js-sticky js-position-sticky top-0 border-top-0 border-bottom p-2 flex-items-center flex-justify-between color-bg-primary rounded-top-2" style="position: sticky; z-index: 30;" >
-    <h3 class="Box-title padding-8px px-2">{type} Dependencies</h3>
+  <div class="d-flex js-position-sticky border-top-0 border-bottom p-2 flex-justify-between color-bg-primary rounded-top-2" style="position: sticky;" >
+    <h3 class="Box-title p-2">{type} Dependencies</h3>
     <div class="npmhub-header BtnGroup">
       <slot></slot>
     </div>

--- a/source/npmhub.css
+++ b/source/npmhub.css
@@ -34,7 +34,3 @@ li.npmhub-empty {
     opacity: 0.5;
   }
 }
-
-.padding-8px{
-  padding: 8px;
-}


### PR DESCRIPTION
Resolves #143 

## Goal

set same format for "readme" and "dependencies" 

## Logic

to solve it, I have added a `div` element with the same class and which makes readme's title. and then to solve the padding problem, I added a class `padding-8px` to the `h3` element of title. 

## Result


Before
![DependenciesOriginal](https://user-images.githubusercontent.com/60680215/136865550-e9fa48de-11f5-4b79-83ef-317a50cfef42.JPG)

After
![DependenciesExpected](https://user-images.githubusercontent.com/60680215/136865568-dec03c35-439a-49ea-8f3b-1caf86f11b9b.JPG)
