### PR TITLE
Fix: Missing background in Box header

### DIFF
--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -7,7 +7,7 @@
 
 
 <div {id} class="Box Box--condensed mt-5 file-holder">
-  <div class="d-flex js-position-sticky border-top-0 border-bottom p-2 flex-justify-between color-bg-primary rounded-top-2" style="position: sticky; {style}">
+  <div class="d-flex js-position-sticky border-top-0 border-bottom p-2 flex-justify-between color-bg-default rounded-top-2" style="position: sticky; {style}">
     <h3 class="Box-title p-2">{type} Dependencies</h3>
     <div class="npmhub-header BtnGroup">
       <slot></slot>


### PR DESCRIPTION
Updates class name to match github's.

Fixes the following:
![image](https://user-images.githubusercontent.com/28708889/156746630-92404819-f928-4558-a331-baaa6f897fc4.png)
