### PR TITLE
fix broken package.json retrieval due to new non-HTML GH architecture

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -16,6 +16,7 @@ const fetchPackageJson = mem(async name => {
   const package_ = await response.json();
 
   if (package_.error) {
+    console.error(name, package_);
     throw new Error(package_.error);
   }
 

--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -97,8 +97,8 @@
       return true;
     }
 
-    if (error.message !== 'Not found') {
-      console.warn(`${errorMessage} pinging the current package on npmjs.org`, error);
+    if (error !== 'Not found') {
+      console.warn(`${errorMessage} pinging the (${name}) package on npmjs.org:`, error);
     }
 
     return false;


### PR DESCRIPTION
@fregante i figure this is already causing you a bunch of drama on refined github.

"this" being https://github.blog/changelog/2022-11-09-introducing-an-all-new-code-search-and-code-browsing-experience/#the-all-new-code-browsing-experience . It just hit my account very recently.

anyway, i tried to help out over here with a fix.   Cuz we can't read textContent now (sometimes?), instead i pull from some embeddedData json that's hiding.


fyi This doesn't need the parcel PR. The two both work separately (and together)