### PR TITLE
Add support for the new GitHub UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,10 @@ To run the extension locally while developing:
 1. Enable "Developer Mode".
 1. Click "Load Unpacked Extension".
 1. Browse to the `/distribution` directory of your checked-out project.
-1. Visit a [Javascripty repo with dependencies](https://github.com/VictorBjelkholm/trymodule) and you should see dependencies listed below the README.
+1. Visit a [Javascripty repo with dependencies](https://github.com/fregante/GhostText) and you should see dependencies listed below the README.
 
 ## Deployment
 
-Changes to the master branch are deployed automatically to the Chrome web store.
+Changes to the main branch are deployed automatically to the Chrome web store.
 Once your PR is merged, the updates should be live after a few minutes but it
 can sometimes take up to an hour for the Chrome web store to update.

--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -1,6 +1,4 @@
 <script>
-  import elementReady from 'element-ready';
-  import fetchDom from '../lib/fetch-dom';
   import Box from './Box.svelte';
   import HeaderLink from './HeaderLink.svelte';
 
@@ -14,9 +12,12 @@
   }
 
   async function getPackageJson() {
-    const document_ = isPackageJson ? document : await fetchDom(packageURL);
-    const jsonBlobElement = await elementReady('.blob-wrapper table', {target: document_});
-    return JSON.parse(jsonBlobElement.textContent);
+    const urlParts = packageURL.split('/');
+    urlParts[5] = 'raw';
+    const rawUrl = urlParts.join('/');
+    const request = await fetch(rawUrl);
+    const packageJson = await request.text();
+    return JSON.parse(packageJson);
   }
 
   async function getLocalPackage() {

--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -6,7 +6,7 @@
 </script>
 
 
-<div {id} class="Box Box--condensed mt-5 file-holder">
+<div {id} class="Box Box--condensed my-5 file-holder">
   <div class="d-flex js-position-sticky border-top-0 border-bottom p-2 flex-justify-between color-bg-default rounded-top-2" style="position: sticky; {style}">
     <h3 class="Box-title p-2">{type} Dependencies</h3>
     <div class="npmhub-header BtnGroup">

--- a/source/npmhub.js
+++ b/source/npmhub.js
@@ -4,7 +4,7 @@ import App from './components/App.svelte';
 
 function isPackageJson() {
   // Example URLs:
-  // https://github.com/npmhub/npmhub/blob/master/package.json
+  // https://github.com/npmhub/npmhub/blob/main/package.json
   const pathnameParts = window.location.pathname.split('/');
   return pathnameParts[3] === 'blob' && pathnameParts.pop() === 'package.json';
 }
@@ -14,14 +14,17 @@ function hasPackageJson() {
 }
 
 function getPackageURL() {
-  const packageLink = document.querySelector([
-    '#files ~ div [title="package.json"]', // GitHub
-    '.files [title="package.json"]', // GitHub before "Repository refresh"
-  ]);
-
-  if (packageLink) {
-    return packageLink.href;
+  if (isPackageJson()) {
+    return location.origin + location.pathname;
   }
+
+  // Example URLs:
+  // https://github.com/npmhub/npmhub
+  // https://github.com/eslint/eslint/tree/main/packages/eslint-config-eslint
+  return document.querySelector([
+    '.react-directory-filename-column [title="package.json"] a',
+    '#files ~ div [title="package.json"]', // GitHub pre-2022 refresh
+  ])?.href;
 }
 
 async function init() {
@@ -38,7 +41,7 @@ async function init() {
 
   if (
     document.querySelector('.npmhub-header')
-    || !(isPackageJson() || hasPackageJson())
+    || !hasPackageJson()
   ) {
     return;
   }


### PR DESCRIPTION
Replaces and closes https://github.com/npmhub/npmhub/pull/157

It triggers a request on every page with `package.json`, but at least it's consistent and safe. I'm not sure why we didn't do this before (last famous words)

It seems to work everywhere:

- repo: https://github.com/npmhub/npmhub
- file: https://github.com/npmhub/npmhub/blob/main/package.json
- sub-folder: https://github.com/eslint/eslint/tree/main/packages/eslint-config-eslint
- other branch: https://github.com/npmhub/npmhub/tree/ios

The previous AJAX-related issue persists, so you'd still have to refresh the page. I think #159 will fix that too