### PR TITLE
Fix fetch package.json in Firefox

### DIFF
--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -11,10 +11,18 @@
     return type.toLowerCase() + 'Dependencies';
   }
 
+  /**
+   * Transform urls like: https://github.com/sindresorhus/delay/blob/main/package.json
+   * into urls like:      https://raw.githubusercontent.com/sindresorhus/delay/main/package.json
+   * to be able to download package.json's contents as JSON.
+   */
   async function getPackageJson() {
-    const urlParts = packageURL.split('/');
-    urlParts[5] = 'raw';
-    const rawUrl = urlParts.join('/');
+    const parsedUrl = new URL(packageURL);
+    parsedUrl.hostname = 'raw.githubusercontent.com';
+    const pathParts = parsedUrl.pathname.split('/');
+    pathParts.splice(3, 1);
+    parsedUrl.pathname = pathParts.join('/');
+    const rawUrl = parsedUrl.toString();
     const request = await fetch(rawUrl);
     const packageJson = await request.text();
     return JSON.parse(packageJson);

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -36,6 +36,7 @@
   },
   "permissions": [
     "https://registry.npmjs.org/",
+    "https://raw.githubusercontent.com/",
     "contextMenus",
     "activeTab"
   ],


### PR DESCRIPTION
## Problem description
This plugin generates the following URL to download the contents of a `package.json`: `https://github.com/<user>/<project>/blob/main/package.json`. GitHub then redirects this URL to the following one: `https://raw.githubusercontent.com/<user>/<project>/main/package.json`. At least in Firefox, this leads to unspecific errors (`NetworkError` with code `0`) when downloading the requested `package.json`.

I'm not sure whether GitHub changed the URLs to raw file downloads and now uses a different domain or whether Firefox started checking the URLs after a redirect for matches with the permissions list from the manifest. Either way, at least in Firefox this leads to dependencies not being displayed any more and this plugin to effectively become useless.

## Implementation details
It would be enough to add the `raw.githubusercontent.com` to the list of permissions to fix the problem in Firefox. However, I thought that it would make sense to change the URL to the redirected one to save time for the redirect and to do one request less to reduce the count of requests to the absolutely necessary minimum.