### PR TITLE
Show real error in UI

### DIFF
--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -28,6 +28,7 @@
     if (!response.ok) {
       throw new Error('Request failed while fetching the current package.json');
     }
+  
     return response.json();
   }
 

--- a/source/components/App.svelte
+++ b/source/components/App.svelte
@@ -24,8 +24,11 @@
     const rawUrl = urlParts.join('/');
     // Fetching from the content script enables support for private repos.
     // Do not change this to use `raw.githubusercontent.com` for the same reason.
-    const request = await localFetch(rawUrl);
-    return request.json();
+    const response = await localFetch(rawUrl);
+    if (!response.ok) {
+      throw new Error('Request failed while fetching the current package.json');
+    }
+    return response.json();
   }
 
   async function getLocalPackage() {
@@ -83,7 +86,6 @@
     'Dev',
   ];
 
-  // TODO: also show error in the UI
   const packagePromise = getLocalPackage();
   packagePromise.catch(error => {
     console.warn(`${errorMessage} fetching the current package.json from ${window.location.hostname}`, error);

--- a/source/components/Box.svelte
+++ b/source/components/Box.svelte
@@ -46,9 +46,9 @@
           {/each}
         {/if}
       {/if}
-    {:catch}
+    {:catch error}
       <li class="npmhub-empty">
-        <em>There was a network error.</em>
+        <em>{error}</em>
       </li>
     {/await}
   </ol>


### PR DESCRIPTION
- All errors were shown as a static "network error"
- HTTP errors were silenced

## 404 example before/after

<img width="476" alt="Screenshot 8" src="https://github.com/npmhub/npmhub/assets/1402241/d5301ed9-eb14-4853-ad58-96f0af7a5b13">


<img width="476" alt="Screenshot 7" src="https://github.com/npmhub/npmhub/assets/1402241/e9e95a83-6e28-4613-97b6-00967abc7b2b">
